### PR TITLE
Document Eigen example motivations and mathematical context

### DIFF
--- a/examples/eigen/aees_mixture.cpp
+++ b/examples/eigen/aees_mixture.cpp
@@ -20,6 +20,21 @@
  
 /*
  * Sampling from a Gaussian Mixture Distribution using the Adaptive Equi-Energy Sampler (AEES)
+ *
+ * Context for newcomers:
+ *   - Problem: explore a two-component Gaussian mixture in two dimensions.
+ *     Each component concentrates near a different mode, so simple random walk
+ *     proposals tend to get stuck.
+ *   - Mathematical target: target density is p(x) = 0.5 * N(x | mu_1, sigma_1^2
+ *     I) + 0.5 * N(x | mu_2, sigma_2^2 I).  Its log-density is the log-sum-exp
+ *     of two Gaussian kernels, producing energy barriers between the modes that
+ *     motivate tempering.
+ *   - Why the mcmc library: the Adaptive Equi-Energy Sampler maintains energy
+ *     rings at different temperatures and performs energy-matching swaps to
+ *     jump between modes—functionality provided by the library implementation.
+ *   - Why Eigen: mixture parameters, proposal covariance matrices, and output
+ *     draws are stored as Eigen matrices/vectors, allowing concise linear
+ *     algebra expressions compatible with the AEES interface.
  */
 
 // $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ aees_mixture.cpp -o aees_mixture.out -L./../.. -lmcmc

--- a/examples/eigen/de_normal_mean.cpp
+++ b/examples/eigen/de_normal_mean.cpp
@@ -20,6 +20,22 @@
  
 /*
  * Sampling from a Gaussian distribution using DE-MCMC
+ *
+ * Context for newcomers:
+ *   - Problem: infer the mean of a Normal distribution with known variance
+ *     under a Normal prior, mirroring the setup from the RWMH example but using
+ *     a population-based strategy.
+ *   - Mathematical target: the posterior density for mu given data x_1,...,x_n
+ *     and known sigma is Normal with precision n/sigma^2 + 1/sigma_0^2 and mean
+ *     proportional to sum_i x_i / sigma^2 + mu_0 / sigma_0^2.  We nevertheless
+ *     approximate it numerically to illustrate population proposals.
+ *   - Why the mcmc library: Differential Evolution MCMC (DE-MCMC) evolves an
+ *     ensemble of chains whose proposals depend on pairwise differences.  The
+ *     library manages the population bookkeeping, mutation steps, and
+ *     acceptance statistics.
+ *   - Why Eigen: ensemble members, data vectors, and proposal differences are
+ *     represented as Eigen objects, allowing concise linear algebra while
+ *     interoperating with the DE-MCMC interface.
  */
 
 // $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ de_normal_mean.cpp -o de_normal_mean.out -L./../.. -lmcmc

--- a/examples/eigen/function_gaussian_sampler.cpp
+++ b/examples/eigen/function_gaussian_sampler.cpp
@@ -31,7 +31,10 @@
  *       f(x) = -\tfrac{1}{2} (x - mu)^T diag(\sigma^{-2}) (x - mu)
  *              - \tfrac{1}{2} \sum_j \log(2\pi\sigma_j^2),
  *     which is the exact Normal log pdf with mean mu and component-wise
- *     standard deviations sigma_j.  We expose both the value of f and its
+ *     standard deviations sigma_j.  Working with log p(x) rather than p(x)
+ *     avoids numerical underflow for high-dimensional states and makes
+ *     constant factors in p(x) irrelevant because MCMC only requires ratios
+ *     p(x') / p(x) = exp(f(x') - f(x)).  We expose both the value of f and its
  *     gradient \nabla f(x) = - diag(\sigma^{-2}) (x - mu) so that gradient-based
  *     samplers can be employed.
  *   - Why the mcmc library: the Hamiltonian Monte Carlo routine handles the

--- a/examples/eigen/function_gaussian_sampler.cpp
+++ b/examples/eigen/function_gaussian_sampler.cpp
@@ -1,0 +1,129 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2011-2023 Keith O'Hara
+  ##
+  ##   This file is part of the MCMC C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+/*
+ * Sampling from a multivariate Gaussian defined as a function f: R^n -> R
+ *
+ * Context for newcomers:
+ *   - Problem: draw samples from a target density specified only through a
+ *     log-density function f(x) = log p(x) on R^n.  Here we pick a
+ *     multivariate Normal with known mean vector and diagonal covariance to
+ *     illustrate how to plug a mathematical description directly into an MCMC
+ *     sampler without relying on conjugacy.
+ *   - Mathematical target: for x in R^n, the log-density is
+ *       f(x) = -\tfrac{1}{2} (x - mu)^T diag(\sigma^{-2}) (x - mu)
+ *              - \tfrac{1}{2} \sum_j \log(2\pi\sigma_j^2),
+ *     which is the exact Normal log pdf with mean mu and component-wise
+ *     standard deviations sigma_j.  We expose both the value of f and its
+ *     gradient \nabla f(x) = - diag(\sigma^{-2}) (x - mu) so that gradient-based
+ *     samplers can be employed.
+ *   - Why the mcmc library: the Hamiltonian Monte Carlo routine handles the
+ *     numerical integration and accept-reject mechanics required to simulate
+ *     from e^{f(x)}.  We only need to provide f and \nabla f in Eigen types.
+ *   - Why Eigen: the state vector lives in R^n.  Eigen arrays/vectors provide a
+ *     compact way to evaluate quadratic forms, gradients, and to interoperate
+ *     with the library's wrappers.
+ */
+
+// $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ function_gaussian_sampler.cpp -o function_gaussian_sampler.out -L./../.. -lmcmc
+
+#define MCMC_ENABLE_EIGEN_WRAPPERS
+#include "mcmc.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <numeric>
+
+struct gaussian_target_data {
+    Eigen::VectorXd mean;
+    Eigen::VectorXd inv_var;
+    double log_normalization;
+    int dim;
+};
+
+inline double log_gaussian_density(const Eigen::VectorXd& x, Eigen::VectorXd* grad_out, void* data)
+{
+    gaussian_target_data* params = reinterpret_cast<gaussian_target_data*>(data);
+
+    const Eigen::ArrayXd diff = x.array() - params->mean.array();
+    const double quad_form = (diff.square() * params->inv_var.array()).sum();
+
+    if (grad_out) {
+        grad_out->resize(params->dim);
+        grad_out->array() = -diff * params->inv_var.array();
+    }
+
+    return params->log_normalization - 0.5 * quad_form;
+}
+
+int main()
+{
+    const int dim = 3;
+
+    Eigen::VectorXd mean(dim);
+    mean << 1.5, -0.5, 2.0;
+
+    Eigen::VectorXd std_dev(dim);
+    std_dev << 1.0, 0.6, 1.8;
+
+    const double pi = 3.14159265358979323846;
+
+    gaussian_target_data params;
+    params.mean = mean;
+    params.inv_var = std_dev.array().square().inverse().matrix();
+    params.dim = dim;
+    params.log_normalization = -std_dev.array().log().sum()
+                              - 0.5 * static_cast<double>(dim) * std::log(2.0 * pi);
+
+    Eigen::VectorXd initial_val = mean + Eigen::VectorXd::Constant(dim, 0.2);
+
+    mcmc::algo_settings_t settings;
+    settings.hmc_settings.step_size = 0.15;
+    settings.hmc_settings.n_leap_steps = 20;
+    settings.hmc_settings.n_burnin_draws = 1500;
+    settings.hmc_settings.n_keep_draws = 3000;
+
+    Eigen::MatrixXd draws_out;
+    mcmc::hmc(initial_val, log_gaussian_density, draws_out, &params, settings);
+
+    std::cout << "Acceptance rate: "
+              << static_cast<double>(settings.hmc_settings.n_accept_draws) / settings.hmc_settings.n_keep_draws
+              << std::endl;
+
+    const auto n_draws = static_cast<std::size_t>(draws_out.rows());
+
+    for (int j = 0; j < dim; ++j) {
+        const double* begin = draws_out.col(j).data();
+        const double* end = begin + n_draws;
+
+        const double sample_mean = std::accumulate(begin, end, 0.0) / static_cast<double>(n_draws);
+        const double sq_sum = std::inner_product(begin, end, begin, 0.0);
+        const double sample_var = sq_sum / static_cast<double>(n_draws) - sample_mean * sample_mean;
+        const double sample_std = std::sqrt(sample_var);
+
+        std::cout << "Dimension " << j << ":\n";
+        std::cout << "  sample mean  = " << sample_mean << " (truth " << mean(j)
+                  << ")\n";
+        std::cout << "  sample std   = " << sample_std << " (truth " << std_dev(j)
+                  << ")\n";
+    }
+
+    return 0;
+}

--- a/examples/eigen/mala_normal.cpp
+++ b/examples/eigen/mala_normal.cpp
@@ -20,6 +20,22 @@
  
 /*
  * Sampling from a Gaussian distribution using MALA
+ *
+ * Context for newcomers:
+ *   - Problem: estimate the mean and standard deviation of a Normal
+ *     distribution when both are unknown.  We build a probabilistic model for
+ *     these parameters and wish to draw posterior samples.
+ *   - Mathematical target: condition on data x_1,...,x_n ~ Normal(mu, sigma^2)
+ *     with an improper prior pi(mu,log sigma) proportional to 1.  The
+ *     log-posterior ell(mu,sigma) = -n log sigma - 0.5 sigma^{-2} sum_i (x_i -
+ *     mu)^2 provides the score vector used by the Langevin proposal.
+ *   - Why the mcmc library: the Metropolis-adjusted Langevin algorithm (MALA)
+ *     combines gradient information with random perturbations; this library
+ *     provides the carefully tuned proposal mechanics and bookkeeping needed
+ *     for the method.
+ *   - Why Eigen: gradients, parameter vectors, and proposal perturbations are
+ *     stored as Eigen vectors/matrices, letting us express the underlying
+ *     calculus in a familiar linear algebra language.
  */
 
 // $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ mala_normal.cpp -o mala_normal.out -L./../.. -lmcmc

--- a/examples/eigen/nuts_normal.cpp
+++ b/examples/eigen/nuts_normal.cpp
@@ -20,6 +20,21 @@
  
 /*
  * Sampling from a Gaussian distribution using NUTS
+ *
+ * Context for newcomers:
+ *   - Problem: recover the mean and standard deviation of a Normal
+ *     distribution from data when we only observe noisy draws.
+ *   - Mathematical target: given x_1,...,x_n ~ Normal(mu, sigma^2) with a
+ *     constant prior on (mu, log sigma), the joint posterior density is
+ *     proportional to sigma^{-n} exp(-0.5 sigma^{-2} sum_i (x_i - mu)^2).  The
+ *     gradients of this log-density drive the Hamiltonian dynamics.
+ *   - Why the mcmc library: the No-U-Turn Sampler (NUTS) adapts the path
+ *     length of Hamiltonian trajectories automatically; implementing this
+ *     correctly requires careful bookkeeping supplied by the library.
+ *   - Why Eigen: the sampler manipulates state vectors, gradients, and energy
+ *     metrics that naturally live in linear algebra objects.  Eigen gives us
+ *     convenient vectorized expressions and is directly supported by the
+ *     library wrappers enabled below.
  */
 
 // $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ nuts_normal.cpp -o nuts_normal.out -L./../.. -lmcmc

--- a/examples/eigen/rwmh_normal_mean.cpp
+++ b/examples/eigen/rwmh_normal_mean.cpp
@@ -20,6 +20,22 @@
  
 /*
  * Sampling from a Gaussian distribution using RWMH
+ *
+ * Context for newcomers:
+ *   - Problem: infer the unknown mean of a Normal distribution when the
+ *     variance is known and we have a conjugate Normal prior on the mean.
+ *   - Mathematical target: likelihood L(mu) proportional to exp(-0.5 sigma^{-2}
+ *     sum_i (x_i - mu)^2) with prior mu ~ Normal(mu_0, sigma_0^2).  The
+ *     resulting posterior is Normal(mu_n, sigma_n^2) where sigma_n^{-2} =
+ *     n/sigma^2 + 1/sigma_0^2 and mu_n = sigma_n^2 (sum_i x_i / sigma^2 +
+ *     mu_0 / sigma_0^2), but we purposely simulate it via Metropolis to expose
+ *     the algorithmic workflow.
+ *   - Why the mcmc library: the Random-Walk Metropolis-Hastings (RWMH)
+ *     algorithm implements accept/reject logic and tuning parameters for the
+ *     proposal kernel, sparing us from writing boilerplate control flow.
+ *   - Why Eigen: even in one dimension, the sampler expects parameter vectors
+ *     and data containers compatible with Eigen so that the same interface
+ *     works in higher-dimensional models.
  */
 
 // $CXX -Wall -std=c++14 -O3 -mcpu=native -ffp-contract=fast -I$EIGEN_INCLUDE_PATH -I./../../include/ rwmh_normal_mean.cpp -o rwmh_normal_mean.out -L./../.. -lmcmc


### PR DESCRIPTION
## Summary
- add contextual comment blocks to each Eigen-based example explaining the statistical problem being solved
- describe why the mcmc library implementation is needed for each sampler variant
- note the role of Eigen objects in expressing parameters, gradients, and proposal mechanics
- highlight the precise posterior or target density each example approximates, including key formulas to support the narrative

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfc06471dc83279f7a767917073cd3